### PR TITLE
[fix] Subscribe page 에서 ProductItem props 수정

### DIFF
--- a/src/app/(user)/mypage/subscribe/SubItemList.tsx
+++ b/src/app/(user)/mypage/subscribe/SubItemList.tsx
@@ -1,10 +1,34 @@
 import ProductItem from '@/components/ProductItem';
+import { Product } from '@/types';
 
-export default function SubItemList() {
+type Props = {
+    currentStep: number;
+};
+
+const getData = async () => {
+    const res = await fetch('https://api.fesp.shop/products', {
+        method: 'GET',
+        headers: {
+            // 'Content-Type': 'application/json',
+            'client-id': '05-ILB',
+        },
+    });
+
+    if (!res.ok) {
+        throw new Error('Failed to fetch data');
+    }
+    return res.json();
+};
+
+export default async function SubItemList({ currentStep }: Props) {
+    const { item }: { item: Product[] } = await getData();
+    const dataFilter: Product[] = item.filter(
+        item => item.step === currentStep,
+    );
     return (
         <div className='grid grid-cols-[100px_100px_100px] justify-around gap-y-7 py-7 mb-[60px] border-[1px] border-primary-foreground rounded-[30px]'>
-            {Array.from({ length: 10 }).map((_, i) => (
-                <ProductItem key={i} />
+            {dataFilter.map((item, i) => (
+                <ProductItem key={i} item={item} />
             ))}
         </div>
     );

--- a/src/app/(user)/mypage/subscribe/page.tsx
+++ b/src/app/(user)/mypage/subscribe/page.tsx
@@ -2,6 +2,8 @@ import Image from 'next/image';
 import SubItemList from './SubItemList';
 
 export default function Subscribe() {
+    // 현재 구독중인 Step을 유저 정보에서 가져와 넣어주어야한다.
+    const currentStep = 2;
     return (
         <section>
             <Image
@@ -60,7 +62,7 @@ export default function Subscribe() {
                     </span>
                 </div>
             </div>
-            <SubItemList />
+            <SubItemList currentStep={currentStep} />
         </section>
     );
 }


### PR DESCRIPTION
## Issue

close: #

## 구현 기능

- Subscribe page의  ProductItem props 수정

## 전달 사항

- Subscribe page에서 user 정보를 받아와서 현재 step 값을 넣어주어야합니다.
- `user - extra - baby - month` 

## 기타

no response
